### PR TITLE
Smart verification with STOPPED status

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you need custom configurations to be passed on `run_task`, you can have a jso
     task_params_file: './my-task-params-file.json' # the default name is 'task-params.json'
 ```
 
-You can also choose not to wait for the task to be running. It can be useful to spare some CI/CD minutes, but you'll need another mechanism to be sure your runner is available before running the actual job.
+You can also choose not to wait for the task to be running. It can be useful to spare some CI/CD minutes, but you'll need another mechanism to be sure your [runner is available](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html) before running the actual job.
 
 ```yaml
 - name: Provide a self hosted to execute this job

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest==6.1.*
 pytest-cov==2.10.*
 moto==1.3.*
+mock==4.0.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ line_length=88
 
 [tool:pytest]
 testpaths=tests
+mock_use_standalone_module = true
 
 [flake8]
 ignore = E203, E266, E501, W503


### PR DESCRIPTION
- Smaller pooling interactions to save some bootstraping time
- Handling early STOPPED tasks (e.g. due lack of resources in the cluster for too long) to fail faster
- Starts pooling with a real status to avoid unnecessary first interaction
- Wait testing
- Add `mock` as a standalone dep. It usually comes along with `pytest` but it is better be sure. 