### PR TITLE
Fix executions where task_count > 10

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: 'Whether the action should wait until at least one task is in state RUNNING before finishing'
     required: true
     default: 'true'
-  count:
+  task_count:
     description: 'How many task instances should be triggered'
     required: true
     default: '1'

--- a/action/start.py
+++ b/action/start.py
@@ -32,15 +32,14 @@ def start():
     config = TaskConfig(task_params_file)
     config.set_repository(env["GITHUB_REPOSITORY"])
     config.set(
-        **dict(
-            input.as_dict(),
-            group=config.repository,
-            startedBy=env.get("GITHUB_ACTOR", "UNKNOWN"),
-            count=int(env.get("INPUT_COUNT", 1)),
-        )
+        **input.as_dict(),
+        group=config.repository,
+        startedBy=env.get("GITHUB_ACTOR", "UNKNOWN"),
     )
+    config.task_count = int(env.get("INPUT_TASK_COUNT", 1))
+
     logger.info(
-        f"Start task execution with defition '{config.task_definition}' on cluster '{config.cluster}'"
+        f"Start task execution with definition '{config.task_definition}' on cluster '{config.cluster}'"
     )
     config.set_container_env(
         {


### PR DESCRIPTION
- Since boto3's run task has a 10 limit for count, we need to split executions bigger than that in several requests
- Update docs 
- Add tests
- Replace freshely `count` param with `task_count`, to avoid passing the param direct to the TaskConfig so we can operate over it.  